### PR TITLE
Add log severity and corresponding console colors

### DIFF
--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -71,15 +71,15 @@ namespace Terracord
       }
       catch(FileNotFoundException fnfe)
       {
-        Util.Log($"Unable to parse terracord.xml: {fnfe.Message}");
+        Util.Log($"Unable to parse terracord.xml: {fnfe.Message}", Util.Severity.Error);
         Generate();
       }
       // This will catch and log anything else such as SecurityException for a permission issue, FormatException during conversion, etc.
       catch(Exception e)
       {
-        Util.Log($"Unable to parse terracord.xml: {e.Message}");
+        Util.Log($"Unable to parse terracord.xml: {e.Message}", Util.Severity.Error);
       }
-      Util.Log("terracord.xml parsed.");
+      Util.Log("terracord.xml parsed.", Util.Severity.Info);
       // Display configuration values
       if(Config.DebugMode)
         Display();
@@ -87,17 +87,17 @@ namespace Terracord
 
     public static void Display()
     {
-      Util.Log("Configuration Values");
-      Util.Log("--------------------");
-      Util.Log($"Bot Token: {BotToken}");
-      Util.Log($"Channel ID: {ChannelId}");
-      Util.Log($"Command Prefix: {CommandPrefix}");
-      Util.Log($"Bot Game: {BotGame}");
-      Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}");
-      Util.Log($"Log Chat: {LogChat}");
-      Util.Log($"Debug Mode: {DebugMode}");
-      Util.Log($"Timestamp Format: {TimestampFormat}");
-      Util.Log($"Exception Abort: {AbortOnError}");
+      Util.Log("Configuration Values", Util.Severity.Debug);
+      Util.Log("--------------------", Util.Severity.Debug);
+      Util.Log($"Bot Token: {BotToken}", Util.Severity.Debug);
+      Util.Log($"Channel ID: {ChannelId}", Util.Severity.Debug);
+      Util.Log($"Command Prefix: {CommandPrefix}", Util.Severity.Debug);
+      Util.Log($"Bot Game: {BotGame}", Util.Severity.Debug);
+      Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}", Util.Severity.Debug);
+      Util.Log($"Log Chat: {LogChat}", Util.Severity.Debug);
+      Util.Log($"Debug Mode: {DebugMode}", Util.Severity.Debug);
+      Util.Log($"Timestamp Format: {TimestampFormat}", Util.Severity.Debug);
+      Util.Log($"Exception Abort: {AbortOnError}", Util.Severity.Debug);
     }
 
     /// <summary>
@@ -105,7 +105,7 @@ namespace Terracord
     /// </summary>
     public static void Generate()
     {
-      Util.Log($"Attempting to generate tshock{Path.DirectorySeparatorChar}terracord.xml since the file did not exist...");
+      Util.Log($"Attempting to generate tshock{Path.DirectorySeparatorChar}terracord.xml since the file did not exist...", Util.Severity.Info);
       try
       {
         StreamWriter newConfigFile = new StreamWriter($"tshock{Path.DirectorySeparatorChar}terracord.xml", false);
@@ -132,14 +132,14 @@ namespace Terracord
         newConfigFile.WriteLine("  <exception abort=\"false\" />\n");
         newConfigFile.WriteLine("</configuration>");
         newConfigFile.Close();
-        Util.Log($"tshock{Path.DirectorySeparatorChar}terracord.xml created successfully.");
-        Util.Log("Please configure your bot token and channel ID before loading the Terracord plugin.");
+        Util.Log($"tshock{Path.DirectorySeparatorChar}terracord.xml created successfully.", Util.Severity.Info);
+        Util.Log("Please configure your bot token and channel ID before loading the Terracord plugin.", Util.Severity.Warning);
         if(AbortOnError)
           Environment.Exit(Util.ExitFailure);
       }
       catch(Exception e)
       {
-        Util.Log($"Unable to create terracord.xml: {e.Message}");
+        Util.Log($"Unable to create terracord.xml: {e.Message}", Util.Severity.Error);
         if(AbortOnError)
           Environment.Exit(Util.ExitFailure);
       }

--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -64,7 +64,7 @@ namespace Terracord
     /// <returns>void</returns>
     public async Task Connect()
     {
-      Util.Log("Connecting to Discord...");
+      Util.Log("Connecting to Discord...", Util.Severity.Info);
       try
       {
         // Connect to Discord
@@ -73,7 +73,7 @@ namespace Terracord
       }
       catch(Exception e)
       {
-        Util.Log($"Unable to connect to Discord: {e.Message}");
+        Util.Log($"Unable to connect to Discord: {e.Message}", Util.Severity.Error);
         if(Config.AbortOnError)
           Environment.Exit(Util.ExitFailure);
       }
@@ -85,7 +85,7 @@ namespace Terracord
       }
       catch(Exception e)
       {
-        Util.Log($"Unable to set game/playing status: {e.Message}");
+        Util.Log($"Unable to set game/playing status: {e.Message}", Util.Severity.Error);
         if(Config.AbortOnError)
           Environment.Exit(Util.ExitFailure);
       }
@@ -102,7 +102,29 @@ namespace Terracord
     /// <returns>Task.CompletedTask</returns>
     private Task Log(LogMessage message)
     {
-      Util.Log(message.ToString());
+      // Consolidate Discord.Net LogSeverity with Terracord Util.Severity
+      Util.Severity severity;
+      switch(message.Severity)
+      {
+        case LogSeverity.Debug:
+        case LogSeverity.Verbose:
+          severity = Util.Severity.Debug;
+          break;
+        case LogSeverity.Info:
+          severity = Util.Severity.Info;
+          break;
+        case LogSeverity.Warning:
+          severity = Util.Severity.Warning;
+          break;
+        case LogSeverity.Error:
+        case LogSeverity.Critical:
+          severity = Util.Severity.Error;
+          break;
+        default:
+          severity = Util.Severity.Info;
+          break;
+      }
+      Util.Log(message.ToString(), severity);
       return Task.CompletedTask;
     }
 
@@ -118,11 +140,11 @@ namespace Terracord
       }
       catch(Exception e)
       {
-        Util.Log($"Unable to acquire Discord channel: {e.Message}");
+        Util.Log($"Unable to acquire Discord channel: {e.Message}", Util.Severity.Error);
       }
 
       // The message below is sent to Discord every time the bot connects/reconnects
-      Util.Log("Relay available.");
+      Util.Log($"Relay available. Connected to Discord as {Client.CurrentUser.ToString()}.", Util.Severity.Info);
       Send("**:white_check_mark: Relay available.**");
       return Task.CompletedTask;
     }
@@ -146,12 +168,12 @@ namespace Terracord
 
         // Relay Discord message to Terraria players
         if(Config.LogChat)
-          Util.Log($"<{message.Author.Username}@Discord> {message.Content}");
+          Util.Log($"<{message.Author.Username}@Discord> {message.Content}", Util.Severity.Info);
         TShock.Utils.Broadcast($"<{message.Author.Username}@Discord> {message.Content}", Config.BroadcastColor[0], Config.BroadcastColor[1], Config.BroadcastColor[2]);
       }
       catch(Exception e)
       {
-        Util.Log($"Unable to broadcast TShock message: {e.Message}");
+        Util.Log($"Unable to broadcast TShock message: {e.Message}", Util.Severity.Error);
       }
 
       return Task.CompletedTask;
@@ -170,7 +192,7 @@ namespace Terracord
       }
       catch(Exception e)
       {
-        Util.Log($"Unable to send Discord message: {e.Message}");
+        Util.Log($"Unable to send Discord message: {e.Message}", Util.Severity.Error);
       }
     }
   }

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -83,8 +83,8 @@ namespace Terracord
     {
       if(disposing)
       {
+        Util.Log("Relay shutting down.", Util.Severity.Info);
         discord.Send("**:octagonal_sign: Relay shutting down.**");
-        Util.Log("Relay shutting down.");
         ServerApi.Hooks.GameInitialize.Deregister(this, OnInitialize);
         ServerApi.Hooks.GamePostInitialize.Deregister(this, OnPostInitialize);
         ServerApi.Hooks.ServerJoin.Deregister(this, OnJoin);
@@ -102,7 +102,7 @@ namespace Terracord
     /// <param name="args">event arguments passed by hook</param>
     private void OnInitialize(EventArgs args)
     {
-      Util.Log("Server has started.");
+      Util.Log("Server has started.", Util.Severity.Info);
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ namespace Terracord
   /// <param name="args">event arguments passed by hook</param>
   private void OnJoin(JoinEventArgs args)
     {
-      Util.Log($"{TShock.Players[args.Who].Name} has joined the server.");
+      Util.Log($"{TShock.Players[args.Who].Name} has joined the server.", Util.Severity.Info);
       discord.Send($"**:heavy_plus_sign: {TShock.Players[args.Who].Name} has joined the server.**");
     }
 
@@ -134,7 +134,7 @@ namespace Terracord
     /// <param name="args">event arguments passed by hook</param>
     private void OnBroadcast(ServerBroadcastEventArgs args)
     {
-      Util.Log($"Server broadcast: {args.Message}");
+      Util.Log($"Server broadcast: {args.Message}", Util.Severity.Info);
       discord.Send($"**:mega: Broadcast:** {args.Message}");
     }
 
@@ -166,7 +166,7 @@ namespace Terracord
       */
 
       if(Config.LogChat)
-        Util.Log($"{TShock.Players[args.Who].Name} said: {args.Text}");
+        Util.Log($"{TShock.Players[args.Who].Name} said: {args.Text}", Util.Severity.Info);
       discord.Send($"**<{TShock.Players[args.Who].Name}>** {args.Text}");
     }
 
@@ -179,12 +179,12 @@ namespace Terracord
       try
       {
         string player = TShock.Players[args.Who].Name;
-        Util.Log($"{player} has left the server.");
+        Util.Log($"{player} has left the server.", Util.Severity.Info);
         discord.Send($"**:heavy_minus_sign: {player} has left the server.**");
       }
       catch(NullReferenceException nre)
       {
-        Util.Log($"Exception caught after player left TShock server: {nre.Message}");
+        Util.Log($"Exception caught after player left TShock server: {nre.Message}", Util.Severity.Error);
       }
     }
   }

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -29,24 +29,52 @@ namespace Terracord
     //private const int ExitSuccess = 0; // unused for now
     public const int ExitFailure = -1;
 
+    // Log severity
+    public enum Severity
+    {
+      Debug = 0,
+      Info = 1,
+      Warning = 2,
+      Error = 3    // includes critical messages and exceptions
+    }
+
     /// <summary>
     /// Writes a log message to terracord.log and the TShock console
     /// </summary>
     /// <param name="logText">the text to log</param>
-    public static void Log(string logText)
+    public static void Log(string logText, Severity severity)
     {
       try
       {
+        switch(severity)
+        {
+          case Severity.Debug:
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            break;
+          case Severity.Info:
+            Console.ForegroundColor = ConsoleColor.White;
+            break;
+          case Severity.Warning:
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            break;
+          case Severity.Error:
+            Console.ForegroundColor = ConsoleColor.Red;
+            break;
+          default:
+            Console.ForegroundColor = ConsoleColor.White;
+            break;
+        }
         StreamWriter logFile = new StreamWriter($"tshock{Path.DirectorySeparatorChar}terracord.log", true);
         // Write to console first in case file is unavailable
         Console.WriteLine($"Terracord: [{DateTime.Now.ToString(Config.TimestampFormat)}] {logText.ToString()}");
+        Console.ResetColor();
         logFile.WriteLine($"[{DateTime.Now.ToString(Config.TimestampFormat)}] {logText.ToString()}");
         logFile.Close();
       }
       catch(Exception e)
       {
         // Log message also gets written to console, so it will be visible
-        Log($"Unable to write to terracord.log: {e.Message}");
+        Log($"Unable to write to terracord.log: {e.Message}", Severity.Error);
         if(Config.AbortOnError)
           Environment.Exit(ExitFailure);
       }

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -66,9 +66,9 @@ namespace Terracord
         }
         StreamWriter logFile = new StreamWriter($"tshock{Path.DirectorySeparatorChar}terracord.log", true);
         // Write to console first in case file is unavailable
-        Console.WriteLine($"Terracord: [{DateTime.Now.ToString(Config.TimestampFormat)}] {logText.ToString()}");
+        Console.WriteLine($"Terracord: [{DateTime.Now.ToString(Config.TimestampFormat)}] [severity.ToString()] {logText.ToString()}");
         Console.ResetColor();
-        logFile.WriteLine($"[{DateTime.Now.ToString(Config.TimestampFormat)}] {logText.ToString()}");
+        logFile.WriteLine($"[{DateTime.Now.ToString(Config.TimestampFormat)}] [severity.ToString()] {logText.ToString()}");
         logFile.Close();
       }
       catch(Exception e)


### PR DESCRIPTION
Proposed Changes
- Terracord messages within the TShock console are now color coded based on severity (closes #30)
