### PR TITLE
Convert received Discord mentions and change uptime command to embed

### DIFF
--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -216,7 +216,7 @@ namespace Terracord
       if(command.Equals("playerlist", StringComparison.OrdinalIgnoreCase))
       {
         string playerList = $"{TShock.Utils.ActivePlayers()}/{TShock.Config.MaxSlots}\n\n";
-        foreach (var player in TShock.Utils.GetPlayers(false))
+        foreach(var player in TShock.Utils.GetPlayers(false))
           playerList += $"{player}\n";
         EmbedBuilder embed = new EmbedBuilder();
         embed.WithColor(Color.Blue)
@@ -260,7 +260,7 @@ namespace Terracord
     /// <returns>modified message text</returns>
     private string ConvertMentions(SocketMessage message)
     {
-       StringBuilder modifiedMessageText = new StringBuilder(message.Content);
+      StringBuilder modifiedMessageText = new StringBuilder(message.Content);
 
       if(message.MentionedChannels.Count > 0)
       {

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -159,14 +159,17 @@ namespace Terracord
        * 1. Check args.Text for regex match of a tag.
        * 2. If 1 or more instances found, iterate through Discord server members to find potential username matches.
        * 3. Replace @user tags in args.Text with user.Mention and send the message
-      var guilds = botClient.Guilds;
+      var guilds = discord.Client.Guilds;
       foreach(var guild in guilds)
       {
-        var members = guild.Users;
-        foreach(var member in members)
+        foreach(var role in guild.Roles)
+          Console.WriteLine(role.Mention);
+        foreach(var channel in guild.TextChannels)
+          Console.WriteLine(channel.Mention);
+        foreach(var user in guild.Users)
         {
-          if("test".Equals(member.Username, StringComparison.OrdinalIgnoreCase))
-            Console.WriteLine($"{member.Mention}");
+          if("test".Equals(user.Username, StringComparison.OrdinalIgnoreCase))
+            Console.WriteLine($"{user.Mention}");
         }
       }
       */


### PR DESCRIPTION
Proposed Changes
- Change `uptime` command response to an embed
- Convert received Discord channel, role, and user mentions to regular text before broadcasting to Terraria players (closes #26)
