### PR TITLE
Improved command specifier relay denial

### DIFF
--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -151,7 +151,7 @@ namespace Terracord
     private void OnChat(ServerChatEventArgs args)
     {
       // Do not relay commands
-      if (args.Text.StartsWith(TShock.Config.CommandSpecifier) || args.Text.StartsWith(TShock.Config.CommandSilentSpecifier))
+      if(args.Text.StartsWith(TShock.Config.CommandSpecifier) || args.Text.StartsWith(TShock.Config.CommandSilentSpecifier))
         return;
 
       /* Initial work on Discord mentions from Terraria

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -151,7 +151,7 @@ namespace Terracord
     private void OnChat(ServerChatEventArgs args)
     {
       // Do not relay commands
-      if(args.Text.StartsWith("/"))
+      if (args.Text.StartsWith(TShock.Config.CommandSpecifier) || args.Text.StartsWith(TShock.Config.CommandSilentSpecifier))
         return;
 
       /* Initial work on Discord mentions from Terraria


### PR DESCRIPTION
MINOR ISSUE
because TShock's config allows the user to change the "/" to whatever they want

Issues with existing solution:
- fails to take into account of the command silent specifier "." (TShock default)
- fails to take into account of the fact that both command specifiers can be configured by the end user

Proposed changes:
- change string to account for config defined command specifiers
- this way no matter what the user decides to change the specifiers to, it would not be relayed to the Discord chat
