### PR TITLE
Add relay Discord bot commands option and offline topic change

### DIFF
--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -32,6 +32,7 @@ namespace FragLand.TerracordPlugin
     public static string BotToken { get; private set; }
     public static ulong ChannelId { get; private set; }
     public static char CommandPrefix { get; private set; }
+    public static bool RelayCommands { get; private set; }
     public static string BotGame { get; private set; }
     public static uint TopicInterval { get; private set; }
     public static byte[] BroadcastColor { get; private set; }
@@ -67,6 +68,7 @@ namespace FragLand.TerracordPlugin
         BotToken = configOptions.Element("bot").Attribute("token").Value.ToString(Locale);
         ChannelId = ulong.Parse(configOptions.Element("channel").Attribute("id").Value.ToString(Locale), Locale);
         CommandPrefix =  char.Parse(configOptions.Element("command").Attribute("prefix").Value.ToString(Locale));
+        RelayCommands = bool.Parse(configOptions.Element("relay").Attribute("commands").Value.ToString(Locale));
         BotGame = configOptions.Element("game").Attribute("status").Value.ToString(Locale);
         TopicInterval = uint.Parse(configOptions.Element("topic").Attribute("interval").Value.ToString(Locale), Locale);
 
@@ -124,6 +126,7 @@ namespace FragLand.TerracordPlugin
       Util.Log($"Bot Token: {BotToken}", Util.Severity.Debug);
       Util.Log($"Channel ID: {ChannelId}", Util.Severity.Debug);
       Util.Log($"Command Prefix: {CommandPrefix}", Util.Severity.Debug);
+      Util.Log($"Relay Commands: {RelayCommands}", Util.Severity.Debug);
       Util.Log($"Bot Game: {BotGame}", Util.Severity.Debug);
       Util.Log($"Topic Interval: {TopicInterval}", Util.Severity.Debug);
       Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}", Util.Severity.Debug);
@@ -152,6 +155,8 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <channel id=\"123\" />\n");
         newConfigFile.WriteLine("  <!-- Bot command prefix -->");
         newConfigFile.WriteLine("  <command prefix=\"!\" />\n");
+        newConfigFile.WriteLine("  <!-- Relay Discord bot commands -->");
+        newConfigFile.WriteLine("  <relay commands=\"true\" />\n");
         newConfigFile.WriteLine("  <!-- Discord bot game for \"playing\" status -->");
         newConfigFile.WriteLine("  <game status=\"Terraria\" />\n");
         newConfigFile.WriteLine("  <!-- Topic update interval in seconds -->");

--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -174,7 +174,11 @@ namespace FragLand.TerracordPlugin
 
         // Handle commands
         if(message.Content.StartsWith(Config.CommandPrefix.ToString(Config.Locale), StringComparison.InvariantCulture) && message.Content.Length > 1)
+        {
           _ = CommandHandler(message.Content); // avoid blocking in MessageReceived() by using discard
+          if(!Config.RelayCommands)
+            return Task.CompletedTask;
+        }
 
         // Check for mentions and convert them to friendly names if found
         string messageContent = Util.ConvertMentions(message);

--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -279,20 +279,30 @@ namespace FragLand.TerracordPlugin
     }
 
     /// <summary>
+    /// Sets the Discord text channel topic
+    /// </summary>
+    /// <param name="topic">new channel topic</param>
+    /// <returns>void</returns>
+    public async Task SetTopic(string topic)
+    {
+      ITextChannel topicChannel = Client.GetChannel(Config.ChannelId) as ITextChannel;
+      await topicChannel.ModifyAsync(chan =>
+      {
+        chan.Topic = topic;
+      }).ConfigureAwait(true);
+    }
+
+    /// <summary>
     /// Periodically updates Discord channel topic
     /// </summary>
     /// <returns>void</returns>
     private async Task UpdateTopic()
     {
-      ITextChannel topicChannel = Client.GetChannel(Config.ChannelId) as ITextChannel;
       UpdateTopicRunning = true;
       while(true)
       {
-        await topicChannel.ModifyAsync(chan =>
-        {
-          chan.Topic = $"{TShock.Utils.ActivePlayers()}/{TShock.Config.MaxSlots} players online " +
-                       $"| Server online for {Util.Uptime()} | Last update: {DateTime.Now.ToString(Config.TimestampFormat, Config.Locale)}";
-        }).ConfigureAwait(true);
+        await SetTopic($"{TShock.Utils.ActivePlayers()}/{TShock.Config.MaxSlots} players online " +
+                       $"| Server online for {Util.Uptime()} | Last update: {DateTime.Now.ToString(Config.TimestampFormat, Config.Locale)}").ConfigureAwait(true);
         try
         {
           await Task.Delay(Convert.ToInt32(Config.TopicInterval * 1000)).ConfigureAwait(true); // seconds to milliseconds

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -92,6 +92,7 @@ namespace FragLand.TerracordPlugin
       {
         Util.Log("Relay shutting down.", Util.Severity.Info);
         discord.Send(Properties.Strings.RelayShutdownString);
+        discord.SetTopic("Relay offline").ConfigureAwait(true);
         ServerApi.Hooks.GameInitialize.Deregister(this, OnInitialize);
         ServerApi.Hooks.GamePostInitialize.Deregister(this, OnPostInitialize);
         ServerApi.Hooks.ServerJoin.Deregister(this, OnJoin);

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -37,7 +37,7 @@ namespace FragLand.TerracordPlugin
     /// <summary>
     /// Plugin version
     /// </summary>
-    public override Version Version => new Version(1, 0, 0);
+    public override Version Version => new Version(1, 1, 0);
 
     /// <summary>
     /// Plugin author(s)
@@ -50,7 +50,7 @@ namespace FragLand.TerracordPlugin
     public override string Description => "A Discord <-> Terraria bridge plugin for TShock";
 
     // Plugin version
-    public const string PluginVersion = "1.0.0";
+    public const string PluginVersion = "1.1.0";
     // Discord bot client
     private readonly Discord discord;
     // Plugin start time

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -177,6 +177,11 @@ namespace FragLand.TerracordPlugin
       PlayerEventNotify(args, Properties.Strings.PlayerLeftString);
     }
 
+    /// <summary>
+    /// Sends Terraria player join/leave events to the Discord text channel
+    /// </summary>
+    /// <param name="eventArgs">event arguments</param>
+    /// <param name="message">message</param>
     private void PlayerEventNotify(object eventArgs, string message)
     {
       //try
@@ -185,20 +190,21 @@ namespace FragLand.TerracordPlugin
         if(eventArgs != null)
         {
           string playerName = null;
-          if(eventArgs is JoinEventArgs)
+          string joinLeaveEmoji = null;
+          if(eventArgs is JoinEventArgs joinEventArgs)
           {
-            JoinEventArgs joinEventArgs = (JoinEventArgs)eventArgs;
             playerName = TShock.Players[joinEventArgs.Who].Name;
+            joinLeaveEmoji = ":heavy_plus_sign:";
           }
-          if(eventArgs is LeaveEventArgs)
+          if(eventArgs is LeaveEventArgs leaveEventArgs)
           {
-            LeaveEventArgs leaveEventArgs = (LeaveEventArgs)eventArgs;
             playerName = TShock.Players[leaveEventArgs.Who].Name;
+            joinLeaveEmoji = ":heavy_minus_sign:";
           }
           if(!String.IsNullOrEmpty(playerName))
           {
             Util.Log($"{playerName} {message}", Util.Severity.Info);
-            discord.Send($"**:heavy_minus_sign: {playerName} {message}**");
+            discord.Send($"**{joinLeaveEmoji} {playerName} {message}**");
           }
         }
       //}

--- a/Terracord/Terracord.csproj
+++ b/Terracord/Terracord.csproj
@@ -6,7 +6,7 @@
     <!-- <TargetFramework>netcoreapp3.1</TargetFramework> -->
     <Platforms>x86</Platforms>
     <Company>Frag Land</Company>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <PackageProjectUrl>http://www.frag.land/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/FragLand/terracord</RepositoryUrl>

--- a/terracord.xml
+++ b/terracord.xml
@@ -12,6 +12,9 @@
   <!-- Bot command prefix -->
   <command prefix="!" />
 
+  <!-- Relay Discord bot commands -->
+  <relay commands="true" />
+
   <!-- Discord bot game for "playing" status -->
   <game status="Terraria" />
 


### PR DESCRIPTION
Proposed Changes
- Fix join/leave event emoji and use `is` type pattern expression in `PlayerEventNotify()`
- Add relay Discord bot commands option (closes #47)
- Indicate that relay is offline during shutdown (closes #53)