### PR TITLE
Add various silence options and improvements

### DIFF
--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -40,6 +40,7 @@ namespace FragLand.TerracordPlugin
     public static string BotGame { get; private set; }
     public static uint TopicInterval { get; private set; }
     public static byte[] BroadcastColor { get; private set; }
+    public static bool SilenceWorldsaves { get; private set; }
     public static bool LogChat { get; private set; }
     public static bool DebugMode { get; private set; }
     public static string LocaleString { get; private set; }
@@ -87,6 +88,7 @@ namespace FragLand.TerracordPlugin
           byte.Parse(configOptions.Element("broadcast").Attribute("blue").Value.ToString(Locale), Locale)
         };
 
+        SilenceWorldsaves = bool.Parse(configOptions.Element("silence").Attribute("worldsaves").Value.ToString(Locale));
         LogChat = bool.Parse(configOptions.Element("log").Attribute("chat").Value.ToString(Locale));
         DebugMode = bool.Parse(configOptions.Element("debug").Attribute("mode").Value.ToString(Locale));
         TimestampFormat = configOptions.Element("timestamp").Attribute("format").Value.ToString(Locale);
@@ -138,6 +140,7 @@ namespace FragLand.TerracordPlugin
       Util.Log($"Bot Game: {BotGame}", Util.Severity.Debug);
       Util.Log($"Topic Interval: {TopicInterval}", Util.Severity.Debug);
       Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}", Util.Severity.Debug);
+      Util.Log($"Silence Worldsaves: {SilenceWorldsaves}", Util.Severity.Debug);
       Util.Log($"Log Chat: {LogChat}", Util.Severity.Debug);
       Util.Log($"Debug Mode: {DebugMode}", Util.Severity.Debug);
       Util.Log($"Locale String: {LocaleString}", Util.Severity.Debug);
@@ -173,6 +176,8 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <topic interval=\"300\" />\n");
         newConfigFile.WriteLine("  <!-- Terraria broadcast color in RGB -->");
         newConfigFile.WriteLine("  <broadcast red=\"255\" green=\"215\" blue=\"0\" />\n");
+        newConfigFile.WriteLine("  <!-- Toggle world saves displayed in Discord -->");
+        newConfigFile.WriteLine("  <silence worldsaves=\"false\" />");
         newConfigFile.WriteLine("  <!-- Log all chat messages -->");
         newConfigFile.WriteLine("  <log chat=\"true\" />\n");
         newConfigFile.WriteLine("  <!-- Debug mode -->");

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -42,7 +42,8 @@ namespace FragLand.TerracordPlugin
     public static byte[] BroadcastColor { get; private set; }
     public static bool SilenceBroadcasts { get; private set; }
     public static bool SilenceChat { get; private set; }
-    public static bool SilenceSaves { get; private set; }
+    public static bool SilenceWorldsaves { get; private set; }
+    public static bool IgnoreChat { get; private set; }
     public static bool LogChat { get; private set; }
     public static bool DebugMode { get; private set; }
     public static string LocaleString { get; private set; }
@@ -92,7 +93,8 @@ namespace FragLand.TerracordPlugin
 
         SilenceBroadcasts = bool.Parse(configOptions.Element("silence").Attribute("broadcasts").Value.ToString(Locale));
         SilenceChat = bool.Parse(configOptions.Element("silence").Attribute("chat").Value.ToString(Locale));
-        SilenceSaves = bool.Parse(configOptions.Element("silence").Attribute("saves").Value.ToString(Locale));
+        SilenceWorldsaves = bool.Parse(configOptions.Element("silence").Attribute("worldsaves").Value.ToString(Locale));
+        IgnoreChat = bool.Parse(configOptions.Element("ignore").Attribute("chat").Value.ToString(Locale));
         LogChat = bool.Parse(configOptions.Element("log").Attribute("chat").Value.ToString(Locale));
         DebugMode = bool.Parse(configOptions.Element("debug").Attribute("mode").Value.ToString(Locale));
         TimestampFormat = configOptions.Element("timestamp").Attribute("format").Value.ToString(Locale);
@@ -146,7 +148,8 @@ namespace FragLand.TerracordPlugin
       Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}", Util.Severity.Debug);
       Util.Log($"Silence Broadcasts: {SilenceBroadcasts}", Util.Severity.Debug);
       Util.Log($"Silence Chat: {SilenceChat}", Util.Severity.Debug);
-      Util.Log($"Silence Saves: {SilenceSaves}", Util.Severity.Debug);
+      Util.Log($"Silence Worldsaves: {SilenceWorldsaves}", Util.Severity.Debug);
+      Util.Log($"Ignore Chat: {IgnoreChat}", Util.Severity.Debug);
       Util.Log($"Log Chat: {LogChat}", Util.Severity.Debug);
       Util.Log($"Debug Mode: {DebugMode}", Util.Severity.Debug);
       Util.Log($"Locale String: {LocaleString}", Util.Severity.Debug);
@@ -183,7 +186,9 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <!-- Terraria broadcast color in RGB -->");
         newConfigFile.WriteLine("  <broadcast red=\"255\" green=\"215\" blue=\"0\" />\n");
         newConfigFile.WriteLine("  <!-- Toggle broadcasts, chat, and world saves displayed in Discord -->");
-        newConfigFile.WriteLine("  <silence broadcasts=\"false\" chat=\"false\" saves=\"false\" />\n");
+        newConfigFile.WriteLine("  <silence broadcasts=\"false\" chat=\"false\" worldsaves=\"false\" />\n");
+        newConfigFile.WriteLine("  <!-- Toggle Discord chat displayed in game -->");
+        newConfigFile.WriteLine("  <ignore chat=\"false\" />\n");
         newConfigFile.WriteLine("  <!-- Log all chat messages -->");
         newConfigFile.WriteLine("  <log chat=\"true\" />\n");
         newConfigFile.WriteLine("  <!-- Debug mode -->");

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -93,7 +93,7 @@ namespace FragLand.TerracordPlugin
 
         SilenceBroadcasts = bool.Parse(configOptions.Element("silence").Attribute("broadcasts").Value.ToString(Locale));
         SilenceChat = bool.Parse(configOptions.Element("silence").Attribute("chat").Value.ToString(Locale));
-        SilenceSaves = bool.Parse(configOptions.Element("silence").Attribute("worldsaves").Value.ToString(Locale));
+        SilenceSaves = bool.Parse(configOptions.Element("silence").Attribute("saves").Value.ToString(Locale));
         IgnoreChat = bool.Parse(configOptions.Element("ignore").Attribute("chat").Value.ToString(Locale));
         LogChat = bool.Parse(configOptions.Element("log").Attribute("chat").Value.ToString(Locale));
         DebugMode = bool.Parse(configOptions.Element("debug").Attribute("mode").Value.ToString(Locale));
@@ -186,7 +186,7 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <!-- Terraria broadcast color in RGB -->");
         newConfigFile.WriteLine("  <broadcast red=\"255\" green=\"215\" blue=\"0\" />\n");
         newConfigFile.WriteLine("  <!-- Toggle broadcasts, chat, and world saves displayed in Discord -->");
-        newConfigFile.WriteLine("  <silence broadcasts=\"false\" chat=\"false\" worldsaves=\"false\" />\n");
+        newConfigFile.WriteLine("  <silence broadcasts=\"false\" chat=\"false\" saves=\"false\" />\n");
         newConfigFile.WriteLine("  <!-- Toggle Discord chat displayed in game -->");
         newConfigFile.WriteLine("  <ignore chat=\"false\" />\n");
         newConfigFile.WriteLine("  <!-- Log all chat messages -->");

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -42,7 +42,7 @@ namespace FragLand.TerracordPlugin
     public static byte[] BroadcastColor { get; private set; }
     public static bool SilenceBroadcasts { get; private set; }
     public static bool SilenceChat { get; private set; }
-    public static bool SilenceWorldsaves { get; private set; }
+    public static bool SilenceSaves { get; private set; }
     public static bool LogChat { get; private set; }
     public static bool DebugMode { get; private set; }
     public static string LocaleString { get; private set; }
@@ -92,7 +92,7 @@ namespace FragLand.TerracordPlugin
 
         SilenceBroadcasts = bool.Parse(configOptions.Element("silence").Attribute("broadcasts").Value.ToString(Locale));
         SilenceChat = bool.Parse(configOptions.Element("silence").Attribute("chat").Value.ToString(Locale));
-        SilenceWorldsaves = bool.Parse(configOptions.Element("silence").Attribute("worldsaves").Value.ToString(Locale));
+        SilenceSaves = bool.Parse(configOptions.Element("silence").Attribute("saves").Value.ToString(Locale));
         LogChat = bool.Parse(configOptions.Element("log").Attribute("chat").Value.ToString(Locale));
         DebugMode = bool.Parse(configOptions.Element("debug").Attribute("mode").Value.ToString(Locale));
         TimestampFormat = configOptions.Element("timestamp").Attribute("format").Value.ToString(Locale);
@@ -146,7 +146,7 @@ namespace FragLand.TerracordPlugin
       Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}", Util.Severity.Debug);
       Util.Log($"Silence Broadcasts: {SilenceBroadcasts}", Util.Severity.Debug);
       Util.Log($"Silence Chat: {SilenceChat}", Util.Severity.Debug);
-      Util.Log($"Silence Worldsaves: {SilenceWorldsaves}", Util.Severity.Debug);
+      Util.Log($"Silence Saves: {SilenceSaves}", Util.Severity.Debug);
       Util.Log($"Log Chat: {LogChat}", Util.Severity.Debug);
       Util.Log($"Debug Mode: {DebugMode}", Util.Severity.Debug);
       Util.Log($"Locale String: {LocaleString}", Util.Severity.Debug);
@@ -182,12 +182,8 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <topic interval=\"300\" />\n");
         newConfigFile.WriteLine("  <!-- Terraria broadcast color in RGB -->");
         newConfigFile.WriteLine("  <broadcast red=\"255\" green=\"215\" blue=\"0\" />\n");
-        newConfigFile.WriteLine("  <!-- Toggle broadcasts displayed in Discord -->");
-        newConfigFile.WriteLine("  <silence broadcasts=\"false\" />");
-        newConfigFile.WriteLine("  <!-- Toggle game chat displayed in Discord -->");
-        newConfigFile.WriteLine("  <silence chat=\"false\" />");
-        newConfigFile.WriteLine("  <!-- Toggle world saves displayed in Discord -->");
-        newConfigFile.WriteLine("  <silence worldsaves=\"false\" />");
+        newConfigFile.WriteLine("  <!-- Toggle broadcasts, chat, and world saves displayed in Discord -->");
+        newConfigFile.WriteLine("  <silence broadcasts=\"false\" chat=\"false\" saves=\"false\" />\n");
         newConfigFile.WriteLine("  <!-- Log all chat messages -->");
         newConfigFile.WriteLine("  <log chat=\"true\" />\n");
         newConfigFile.WriteLine("  <!-- Debug mode -->");

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -42,7 +42,7 @@ namespace FragLand.TerracordPlugin
     public static byte[] BroadcastColor { get; private set; }
     public static bool SilenceBroadcasts { get; private set; }
     public static bool SilenceChat { get; private set; }
-    public static bool SilenceWorldsaves { get; private set; }
+    public static bool SilenceSaves { get; private set; }
     public static bool IgnoreChat { get; private set; }
     public static bool LogChat { get; private set; }
     public static bool DebugMode { get; private set; }
@@ -93,7 +93,7 @@ namespace FragLand.TerracordPlugin
 
         SilenceBroadcasts = bool.Parse(configOptions.Element("silence").Attribute("broadcasts").Value.ToString(Locale));
         SilenceChat = bool.Parse(configOptions.Element("silence").Attribute("chat").Value.ToString(Locale));
-        SilenceWorldsaves = bool.Parse(configOptions.Element("silence").Attribute("worldsaves").Value.ToString(Locale));
+        SilenceSaves = bool.Parse(configOptions.Element("silence").Attribute("worldsaves").Value.ToString(Locale));
         IgnoreChat = bool.Parse(configOptions.Element("ignore").Attribute("chat").Value.ToString(Locale));
         LogChat = bool.Parse(configOptions.Element("log").Attribute("chat").Value.ToString(Locale));
         DebugMode = bool.Parse(configOptions.Element("debug").Attribute("mode").Value.ToString(Locale));
@@ -148,7 +148,7 @@ namespace FragLand.TerracordPlugin
       Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}", Util.Severity.Debug);
       Util.Log($"Silence Broadcasts: {SilenceBroadcasts}", Util.Severity.Debug);
       Util.Log($"Silence Chat: {SilenceChat}", Util.Severity.Debug);
-      Util.Log($"Silence Worldsaves: {SilenceWorldsaves}", Util.Severity.Debug);
+      Util.Log($"Silence Saves: {SilenceSaves}", Util.Severity.Debug);
       Util.Log($"Ignore Chat: {IgnoreChat}", Util.Severity.Debug);
       Util.Log($"Log Chat: {LogChat}", Util.Severity.Debug);
       Util.Log($"Debug Mode: {DebugMode}", Util.Severity.Debug);

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -40,6 +40,8 @@ namespace FragLand.TerracordPlugin
     public static string BotGame { get; private set; }
     public static uint TopicInterval { get; private set; }
     public static byte[] BroadcastColor { get; private set; }
+    public static bool SilenceBroadcasts { get; private set; }
+    public static bool SilenceChat { get; private set; }
     public static bool SilenceWorldsaves { get; private set; }
     public static bool LogChat { get; private set; }
     public static bool DebugMode { get; private set; }
@@ -88,6 +90,8 @@ namespace FragLand.TerracordPlugin
           byte.Parse(configOptions.Element("broadcast").Attribute("blue").Value.ToString(Locale), Locale)
         };
 
+        SilenceBroadcasts = bool.Parse(configOptions.Element("silence").Attribute("broadcasts").Value.ToString(Locale));
+        SilenceChat = bool.Parse(configOptions.Element("silence").Attribute("chat").Value.ToString(Locale));
         SilenceWorldsaves = bool.Parse(configOptions.Element("silence").Attribute("worldsaves").Value.ToString(Locale));
         LogChat = bool.Parse(configOptions.Element("log").Attribute("chat").Value.ToString(Locale));
         DebugMode = bool.Parse(configOptions.Element("debug").Attribute("mode").Value.ToString(Locale));
@@ -140,6 +144,8 @@ namespace FragLand.TerracordPlugin
       Util.Log($"Bot Game: {BotGame}", Util.Severity.Debug);
       Util.Log($"Topic Interval: {TopicInterval}", Util.Severity.Debug);
       Util.Log($"Broadcast Color (RGB): {BroadcastColor[0]}, {BroadcastColor[1]}, {BroadcastColor[2]}", Util.Severity.Debug);
+      Util.Log($"Silence Broadcasts: {SilenceBroadcasts}", Util.Severity.Debug);
+      Util.Log($"Silence Chat: {SilenceChat}", Util.Severity.Debug);
       Util.Log($"Silence Worldsaves: {SilenceWorldsaves}", Util.Severity.Debug);
       Util.Log($"Log Chat: {LogChat}", Util.Severity.Debug);
       Util.Log($"Debug Mode: {DebugMode}", Util.Severity.Debug);
@@ -176,6 +182,10 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <topic interval=\"300\" />\n");
         newConfigFile.WriteLine("  <!-- Terraria broadcast color in RGB -->");
         newConfigFile.WriteLine("  <broadcast red=\"255\" green=\"215\" blue=\"0\" />\n");
+        newConfigFile.WriteLine("  <!-- Toggle broadcasts displayed in Discord -->");
+        newConfigFile.WriteLine("  <silence broadcasts=\"false\" />");
+        newConfigFile.WriteLine("  <!-- Toggle game chat displayed in Discord -->");
+        newConfigFile.WriteLine("  <silence chat=\"false\" />");
         newConfigFile.WriteLine("  <!-- Toggle world saves displayed in Discord -->");
         newConfigFile.WriteLine("  <silence worldsaves=\"false\" />");
         newConfigFile.WriteLine("  <!-- Log all chat messages -->");

--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -182,6 +182,10 @@ namespace FragLand.TerracordPlugin
           return false;
       }
 
+      // Do not relay Discord chat to players if this option is enabled
+      if(Config.IgnoreChat)
+        return false;
+
       // Check for mentions and convert them to friendly names if found
       messageContent = Util.ConvertMentions(message);
 

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -144,8 +144,14 @@ namespace FragLand.TerracordPlugin
     /// <param name="args">event arguments passed by hook</param>
     private void OnBroadcast(ServerBroadcastEventArgs args)
     {
+      // Do not relay game broadcasts to Discord if this option is enabled
+      if(Config.SilenceBroadcasts)
+        return;
+
+      // Filter broadcast messages based on content
       if(Util.FilterBroadcast($"{args.Message}"))
         return;
+
       Util.Log($"Server broadcast: {args.Message}", Util.Severity.Info);
       discord.Send($"**:mega: Broadcast:** {args.Message}");
     }
@@ -156,6 +162,10 @@ namespace FragLand.TerracordPlugin
     /// <param name="args">event arguments passed by hook</param>
     private void OnChat(ServerChatEventArgs args)
     {
+      // Do not relay game chat to Discord if this option is enabled
+      if(Config.SilenceChat)
+        return;
+
       // Do not relay commands or messages from muted players
       if(args.Text.StartsWith(TShock.Config.CommandSpecifier, StringComparison.InvariantCulture) || args.Text.StartsWith(TShock.Config.CommandSilentSpecifier, StringComparison.InvariantCulture) || TShock.Players[args.Who].mute)
         return;

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -258,7 +258,7 @@ namespace FragLand.TerracordPlugin
         return true;
       if(Regex.IsMatch(message, "^.+: .*$"))                // chat message
         return true;
-      if(Config.SilenceWorldsaves)
+      if(Config.SilenceSaves)
       {
         if(message.Equals("Saving world...", StringComparison.OrdinalIgnoreCase) || message.Equals("World saved.", StringComparison.OrdinalIgnoreCase))
           return true;

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -254,14 +254,13 @@ namespace FragLand.TerracordPlugin
     /// <returns>true if message should be filtered or false otherwise</returns>
     public static bool FilterBroadcast(string message)
     {
-      bool retval = false;
-      if(Regex.IsMatch(message, "^.+ has (joined|left).$")) // join/leave events
-        retval = true;
-      if(Regex.IsMatch(message, "^.+: .*$"))                // chat message
-        retval = true;
       if(Regex.IsMatch(message, "^<.+@Discord> .*$"))       // Discord message
-        retval = true;
-      return retval;
+        return true;
+      if(Regex.IsMatch(message, "^.+: .*$"))                // chat message
+        return true;
+      if(Regex.IsMatch(message, "^.+ has (joined|left).$")) // join/leave events
+        return true;
+      return false;
     }
 
     /// <summary>

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -258,6 +258,11 @@ namespace FragLand.TerracordPlugin
         return true;
       if(Regex.IsMatch(message, "^.+: .*$"))                // chat message
         return true;
+      if(Config.SilenceWorldsaves)
+      {
+        if(message.Equals("Saving world...", StringComparison.OrdinalIgnoreCase) || message.Equals("World saved.", StringComparison.OrdinalIgnoreCase))
+          return true;
+      }
       if(Regex.IsMatch(message, "^.+ has (joined|left).$")) // join/leave events
         return true;
       return false;

--- a/terracord.xml
+++ b/terracord.xml
@@ -27,14 +27,8 @@
   <!-- Terraria broadcast color in RGB -->
   <broadcast red="255" green="215" blue="0" />
 
-  <!-- Toggle broadcasts displayed in Discord -->
-  <silence broadcasts="false" />
-
-  <!-- Toggle game chat displayed in Discord -->
-  <silence chat="false" />
-
-  <!-- Toggle world saves displayed in Discord -->
-  <silence worldsaves="false" />
+  <!-- Toggle broadcasts, chat, and world saves displayed in Discord -->
+  <silence broadcasts="false" chat="false" saves="false" />
 
   <!-- Log all chat messages -->
   <log chat="true" />

--- a/terracord.xml
+++ b/terracord.xml
@@ -30,6 +30,9 @@
   <!-- Toggle broadcasts, chat, and world saves displayed in Discord -->
   <silence broadcasts="false" chat="false" saves="false" />
 
+  <!-- Toggle Discord chat displayed in game -->
+  <ignore chat="false" />
+
   <!-- Log all chat messages -->
   <log chat="true" />
 

--- a/terracord.xml
+++ b/terracord.xml
@@ -27,6 +27,9 @@
   <!-- Terraria broadcast color in RGB -->
   <broadcast red="255" green="215" blue="0" />
 
+  <!-- Toggle world saves displayed in Discord -->
+  <silence worldsaves="false" />
+
   <!-- Log all chat messages -->
   <log chat="true" />
 

--- a/terracord.xml
+++ b/terracord.xml
@@ -27,6 +27,12 @@
   <!-- Terraria broadcast color in RGB -->
   <broadcast red="255" green="215" blue="0" />
 
+  <!-- Toggle broadcasts displayed in Discord -->
+  <silence broadcasts="false" />
+
+  <!-- Toggle game chat displayed in Discord -->
+  <silence chat="false" />
+
   <!-- Toggle world saves displayed in Discord -->
   <silence worldsaves="false" />
 


### PR DESCRIPTION
Proposed Changes
- Add options to disable chat and/or broadcasts (closes #71).
- Add option to silence world save broadcasts in Discord (closes #73).
- Optimize `FilterBroadcast()` by returning early and reordering by anticipated frequency.
- Add option to ignore Discord chat in game (closes #80).
