### PR TITLE
Allow custom sender prefix for Discord messages

### DIFF
--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -49,6 +49,7 @@ namespace FragLand.TerracordPlugin
     public static bool DebugMode { get; private set; }
     public static string LocaleString { get; private set; }
     public static CultureInfo Locale { get; private set; }
+    public static string AuthorFormat { get; private set; }
     public static string TimestampFormat { get; private set; }
     public static bool AbortOnError { get; private set; }
 
@@ -99,6 +100,7 @@ namespace FragLand.TerracordPlugin
         LogChat = bool.Parse(configOptions.Element("log").Attribute("chat").Value.ToString(Locale));
         MessageLength = int.Parse(configOptions.Element("message").Attribute("length").Value.ToString(Locale), Locale);
         DebugMode = bool.Parse(configOptions.Element("debug").Attribute("mode").Value.ToString(Locale));
+        AuthorFormat = configOptions.Element("author").Attribute("format").Value.ToString(Locale);
         TimestampFormat = configOptions.Element("timestamp").Attribute("format").Value.ToString(Locale);
         AbortOnError = bool.Parse(configOptions.Element("exception").Attribute("abort").Value.ToString(Locale));
       }
@@ -156,6 +158,7 @@ namespace FragLand.TerracordPlugin
       Util.Log($"Message Length: {MessageLength}", Util.Severity.Debug);
       Util.Log($"Debug Mode: {DebugMode}", Util.Severity.Debug);
       Util.Log($"Locale String: {LocaleString}", Util.Severity.Debug);
+      Util.Log($"Author Format: {AuthorFormat}", Util.Severity.Debug);
       Util.Log($"Timestamp Format: {TimestampFormat}", Util.Severity.Debug);
       Util.Log($"Exception Abort: {AbortOnError}", Util.Severity.Debug);
     }
@@ -200,6 +203,8 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <debug mode=\"false\" />\n");
         newConfigFile.WriteLine("  <!-- Locale -->");
         newConfigFile.WriteLine("  <locale string=\"en-US\" />\n");
+        newConfigFile.WriteLine("  <!-- Discord message author appearance in game -->");
+        newConfigFile.WriteLine("  <author format=\"&lt;%u%@Discord&gt;\" />\n");
         newConfigFile.WriteLine("  <!-- Timestamp format -->");
         newConfigFile.WriteLine("  <timestamp format=\"MM/dd/yyyy HH:mm:ss zzz\" />\n");
         newConfigFile.WriteLine("  <!-- Terminate TShock when an error is encountered -->");

--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -220,9 +220,10 @@ namespace FragLand.TerracordPlugin
         // Relay Discord message to Terraria players
         if(relayMessage)
         {
+          string authorFormat = Config.AuthorFormat.Replace("%u%", message.Author.Username);
           if(Config.LogChat)
-            Util.Log($"<{message.Author.Username}@Discord> {messageContent}", Util.Severity.Info);
-          TShock.Utils.Broadcast($"<{message.Author.Username}@Discord> {messageContent}", Config.BroadcastColor[0], Config.BroadcastColor[1], Config.BroadcastColor[2]);
+            Util.Log($"{authorFormat} {messageContent}", Util.Severity.Info);
+          TShock.Utils.Broadcast($"{authorFormat} {messageContent}", Config.BroadcastColor[0], Config.BroadcastColor[1], Config.BroadcastColor[2]);
         }
       }
       catch(Exception e)

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -254,9 +254,10 @@ namespace FragLand.TerracordPlugin
     /// <returns>true if message should be filtered or false otherwise</returns>
     public static bool FilterBroadcast(string message)
     {
-      if(Regex.IsMatch(message, "^<.+@Discord> .*$"))       // Discord message
+      string discordMessage = Config.AuthorFormat.Replace("%u%", ".+");
+      if(Regex.IsMatch(message, $"^{discordMessage} .*$"))  // Discord message
         return true;
-      if(Regex.IsMatch(message, "^.+: .*$"))                // chat message
+      if(Regex.IsMatch(message, "^.+: .*$"))                // Terraria chat message
         return true;
       if(Config.SilenceSaves)
       {

--- a/terracord.xml
+++ b/terracord.xml
@@ -45,6 +45,9 @@
   <!-- Locale -->
   <locale string="en-US" />
 
+  <!-- Discord message author appearance in game -->
+  <author format="&lt;%u%@Discord&gt;" />
+
   <!-- Timestamp format -->
   <timestamp format="MM/dd/yyyy HH:mm:ss zzz" />
 


### PR DESCRIPTION
Proposed Changes
- Allow custom sender prefix for Discord messages (closes #72).
