### PR TITLE
Update TShock release for CI builds and add net46 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
         - msbuild /p:Configuration=Debug TerracordTest/TerracordTest.csproj
-        - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Terracord/bin/x86/Debug/net46/TerracordTest.dll
+        - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./TerracordTest/bin/Debug/net46/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
         - chmod +x send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ jobs:
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
         - msbuild /p:Configuration=Debug TerracordTest/TerracordTest.csproj
+        - ls -la ./testrunner/xunit.runner.console.2.*
+        - ls -la ./testrunner/xunit.runner.console.2.*/tools
+        - ls -la ./TerracordTest/bin/Debug/net46
         - mono ./testrunner/xunit.runner.console.2.*/tools/xunit.console.exe ./TerracordTest/bin/Debug/net46/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ jobs:
         - nuget restore Terracord.sln
         - TMPDIR=tmp
         - mkdir $TMPDIR
-        - ZIPFILE=TShock_4.4.0_Pre8_Terraria1.4.0.4.zip
+        - ZIPFILE=TShock4.4.0_Pre11_Terraria1.4.0.5.zip
         - cd $TMPDIR
-        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre8/TShock_4.4.0_Pre8_Terraria1.4.0.4.zip
+        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre11/TShock4.4.0_Pre11_Terraria1.4.0.5.zip
         - unzip -q $ZIPFILE OTAPI.dll TerrariaServer.exe ServerPlugins/TShockAPI.dll
         - mkdir -p ../lib
         - mv OTAPI.dll TerrariaServer.exe ServerPlugins/TShockAPI.dll ../lib
@@ -31,9 +31,9 @@ jobs:
         - dotnet restore
         - TMPDIR=tmp
         - mkdir $TMPDIR
-        - ZIPFILE=TShock_4.4.0_Pre8_Terraria1.4.0.4.zip
+        - ZIPFILE=TShock4.4.0_Pre11_Terraria1.4.0.5.zip
         - cd $TMPDIR
-        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre8/TShock_4.4.0_Pre8_Terraria1.4.0.4.zip
+        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre11/TShock4.4.0_Pre11_Terraria1.4.0.5.zip
         - unzip -q $ZIPFILE OTAPI.dll TerrariaServer.exe ServerPlugins/TShockAPI.dll
         - mkdir -p ../lib
         - mv OTAPI.dll TerrariaServer.exe ServerPlugins/TShockAPI.dll ../lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - cd ..
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
-        - msbuild /p:Configuration=Debug TerracordTest.sln
+        - msbuild /p:Configuration=Debug TerracordTest.csproj
         - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Terracord/bin/x86/Debug/net46/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jobs:
       mono: latest
       install:
         - nuget restore Terracord.sln
+        - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
         - TMPDIR=tmp
         - mkdir $TMPDIR
         - ZIPFILE=TShock4.4.0_Pre11_Terraria1.4.0.5.zip
@@ -18,6 +19,8 @@ jobs:
         - cd ..
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
+        - msbuild /p:Configuration=Debug TerracordTest.sln
+        - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Terracord/bin/x86/Debug/net46/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
         - chmod +x send.sh
@@ -39,7 +42,7 @@ jobs:
         - mv OTAPI.dll TerrariaServer.exe ServerPlugins/TShockAPI.dll ../lib
         - cd ..
       script:
-        - dotnet build -c Debug
+        - dotnet build -c Debug -f netstandard2.0
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
         - chmod +x send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
       mono: latest
       install:
         - nuget restore Terracord.sln
-        - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
+        - nuget install xunit.runner.console -OutputDirectory testrunner
         - TMPDIR=tmp
         - mkdir $TMPDIR
         - ZIPFILE=TShock4.4.0_Pre11_Terraria1.4.0.5.zip
@@ -20,7 +20,7 @@ jobs:
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
         - msbuild /p:Configuration=Debug TerracordTest/TerracordTest.csproj
-        - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./TerracordTest/bin/Debug/net46/TerracordTest.dll
+        - mono ./testrunner/xunit.runner.console.2.*/tools/xunit.console.exe ./TerracordTest/bin/Debug/net46/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
         - chmod +x send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
       mono: latest
       install:
         - nuget restore Terracord.sln
-        - nuget install xunit.runner.console -OutputDirectory testrunner
+        - nuget install xunit.runner.console -Version 2.4.1 -OutputDirectory testrunner
         - TMPDIR=tmp
         - mkdir $TMPDIR
         - ZIPFILE=TShock4.4.0_Pre11_Terraria1.4.0.5.zip
@@ -20,10 +20,7 @@ jobs:
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
         - msbuild /p:Configuration=Debug TerracordTest/TerracordTest.csproj
-        - ls -la ./testrunner/xunit.runner.console.2.*
-        - ls -la ./testrunner/xunit.runner.console.2.*/tools
-        - ls -la ./TerracordTest/bin/Debug/net46
-        - mono ./testrunner/xunit.runner.console.2.*/tools/xunit.console.exe ./TerracordTest/bin/Debug/net46/TerracordTest.dll
+        - mono ./testrunner/xunit.runner.console.2.4.1/tools/net46/xunit.console.exe ./TerracordTest/bin/Debug/net46/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
         - chmod +x send.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - cd ..
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
-        - msbuild /p:Configuration=Debug TerracordTest.csproj
+        - msbuild /p:Configuration=Debug TerracordTest/TerracordTest.csproj
         - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Terracord/bin/x86/Debug/net46/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -180,9 +180,10 @@ namespace FragLand.TerracordPlugin
     /// </summary>
     public static void Generate()
     {
-      Util.Log($"Attempting to generate {TerracordPath}terracord.xml since the file did not exist...", Util.Severity.Info);
       try
       {
+        Directory.CreateDirectory(TerracordPath);
+        Util.Log($"Attempting to generate {TerracordPath}terracord.xml since the file did not exist...", Util.Severity.Info);
         StreamWriter newConfigFile = new StreamWriter($"{TerracordPath}terracord.xml", false);
         newConfigFile.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
         newConfigFile.WriteLine("<!-- Terracord configuration -->");

--- a/Terracord/Terracord.csproj
+++ b/Terracord/Terracord.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <!-- xUnit does not support netstandard: https://xunit.net/docs/why-no-netstandard -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- <TargetFramework>netstandard2.0</TargetFramework> -->
     <!-- <TargetFramework>netcoreapp3.1</TargetFramework> -->
+    <!-- Discord.Net 2.1.1 requires >=net46 -->
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <Platforms>x86</Platforms>
     <Company>Frag Land</Company>
     <Version>1.2.1</Version>

--- a/TerracordTest/TerracordTest.cs
+++ b/TerracordTest/TerracordTest.cs
@@ -33,7 +33,7 @@ namespace FragLand.TerracordPluginTests
     public void ConfigGenerateTest()
     {
       Config.Generate();
-      Assert.False(File.Exists($"tshock{Path.DirectorySeparatorChar}terracord.xml"));
+      Assert.True(File.Exists($"tshock{Path.DirectorySeparatorChar}Terracord{Path.DirectorySeparatorChar}terracord.xml"));
     }
 
     /// <summary>

--- a/TerracordTest/TerracordTest.csproj
+++ b/TerracordTest/TerracordTest.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <!-- Mono on Travis CI does not support netcoreapp3.1 yet -->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <!-- <TargetFramework>netcoreapp3.0</TargetFramework> -->
+    <TargetFramework>net46</TargetFramework>
     <IsPackable>false</IsPackable>
     <Platforms>x86</Platforms>
     <Authors>Lloyd Dilley</Authors>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,14 @@ configuration: Debug
 before_build:
   - nuget restore
   - SET TEMPDIR=temp
-  - SET ZIPFILE=TShock_4.4.0_Pre8_Terraria1.4.0.4.zip
+  - SET ZIPFILE=TShock4.4.0_Pre11_Terraria1.4.0.5.zip
   - md %TEMPDIR%
   - cd %TEMPDIR%
-  - curl -fsSLJo %ZIPFILE% https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre8/TShock_4.4.0_Pre8_Terraria1.4.0.4.zip
+  - curl -fsSLJo %ZIPFILE% https://github.com/Pryaxis/TShock/releases/download/v4.4.0-pre11/TShock4.4.0_Pre11_Terraria1.4.0.5.zip
   - 7z e %ZIPFILE% -o..\lib\ OTAPI.dll TerrariaServer.exe TShockAPI.dll -r
 build:
   # Ignore TerracordTest
-  project: Terracord\Terracord.csproj
+  #project: Terracord\Terracord.csproj
   verbosity: minimal
 on_success:
   - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1


### PR DESCRIPTION
## Proposed Changes
- Update TShock release for CI builds.
- Add net46 target (closes #95).
- Test xUnit on AppVeyor.
