### PR TITLE
Fix bug relating to command prefixes and leading whitespace

### DIFF
--- a/Terracord/Command.cs
+++ b/Terracord/Command.cs
@@ -49,7 +49,7 @@ namespace FragLand.TerracordPlugin
     /// <returns>void</returns>
     public static async Task CommandHandler(SocketUser user, IMessageChannel channel, string command)
     {
-      command = command.Substring(Config.CommandPrefix.Length); // remove command prefix
+      command = command.Substring(Config.CommandPrefix.Length).TrimStart(); // remove command prefix
       Util.Log($"Command sent: {command}", Util.Severity.Info);
 
       if(command.Equals("help", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Related to #108.

## Proposed Changes
- Trim leading whitespace when bot command prefix is longer than a single character.
