### PR TITLE
Update Discord.Net library and copyright year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       script:
         - msbuild /p:Configuration=Debug Terracord.sln
         - msbuild /p:Configuration=Debug TerracordTest/TerracordTest.csproj
-        - mono ./testrunner/xunit.runner.console.2.4.1/tools/net46/xunit.console.exe ./TerracordTest/bin/Debug/net46/TerracordTest.dll
+        - mono ./testrunner/xunit.runner.console.2.4.1/tools/net461/xunit.console.exe ./TerracordTest/bin/Debug/net461/TerracordTest.dll
       after_success:
         - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
         - chmod +x send.sh

--- a/Terracord/Command.cs
+++ b/Terracord/Command.cs
@@ -1,6 +1,6 @@
 /*
  * Terracord.cs - A Discord <-> Terraria bridge plugin for TShock
- * Copyright (C) 2019-2020 Lloyd Dilley
+ * Copyright (C) 2019-2021 Lloyd Dilley
  * http://www.frag.land/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -1,6 +1,6 @@
 /*
  * Terracord.cs - A Discord <-> Terraria bridge plugin for TShock
- * Copyright (C) 2019-2020 Lloyd Dilley
+ * Copyright (C) 2019-2021 Lloyd Dilley
  * http://www.frag.land/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -1,6 +1,6 @@
 /*
  * Terracord.cs - A Discord <-> Terraria bridge plugin for TShock
- * Copyright (C) 2019-2020 Lloyd Dilley
+ * Copyright (C) 2019-2021 Lloyd Dilley
  * http://www.frag.land/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -1,6 +1,6 @@
 /*
  * Terracord.cs - A Discord <-> Terraria bridge plugin for TShock
- * Copyright (C) 2019-2020 Lloyd Dilley
+ * Copyright (C) 2019-2021 Lloyd Dilley
  * http://www.frag.land/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/Terracord/Terracord.csproj
+++ b/Terracord/Terracord.csproj
@@ -5,7 +5,8 @@
     <!-- <TargetFramework>netstandard2.0</TargetFramework> -->
     <!-- <TargetFramework>netcoreapp3.1</TargetFramework> -->
     <!-- Discord.Net 2.1.1 requires >=net46 -->
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <!-- Discord.Net 2.3.0 requires >=net461 -->
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Platforms>x86</Platforms>
     <Company>Frag Land</Company>
     <Version>1.2.2</Version>
@@ -13,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/FragLand/terracord</RepositoryUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <Copyright>2019-2020</Copyright>
+    <Copyright>2019-2021</Copyright>
     <Authors>Lloyd Dilley</Authors>
     <Description>A Discord &lt;-&gt; Terraria bridge plugin for TShock</Description>
     <PackageTags>Terraria TShock plugin Discord bridge relay bot chat Mono C# .NET CSharp</PackageTags>
@@ -25,8 +26,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Core" Version="2.1.1" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.1.1" />
+    <PackageReference Include="Discord.Net.Core" Version="2.3.0" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -1,6 +1,6 @@
 /*
  * Terracord.cs - A Discord <-> Terraria bridge plugin for TShock
- * Copyright (C) 2019-2020 Lloyd Dilley
+ * Copyright (C) 2019-2021 Lloyd Dilley
  * http://www.frag.land/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/TerracordTest/TerracordTest.cs
+++ b/TerracordTest/TerracordTest.cs
@@ -1,6 +1,6 @@
 /*
  * Terracord.cs - A Discord <-> Terraria bridge plugin for TShock
- * Copyright (C) 2019-2020 Lloyd Dilley
+ * Copyright (C) 2019-2021 Lloyd Dilley
  * http://www.frag.land/
  *
  * This program is free software; you can redistribute it and/or modify

--- a/TerracordTest/TerracordTest.csproj
+++ b/TerracordTest/TerracordTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Mono on Travis CI does not support netcoreapp3.1 yet -->
     <!-- <TargetFramework>netcoreapp3.0</TargetFramework> -->
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
     <Platforms>x86</Platforms>
     <Authors>Lloyd Dilley</Authors>

--- a/TerracordTest/TerracordTest.csproj
+++ b/TerracordTest/TerracordTest.csproj
@@ -11,7 +11,7 @@
     <Product>TerracordTest</Product>
     <Version>1.0.2</Version>
     <Description>Terracord unit tests</Description>
-    <Copyright>2019-2020</Copyright>
+    <Copyright>2019-2021</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>http://www.frag.land/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/FragLand/terracord</RepositoryUrl>


### PR DESCRIPTION
## Proposed Changes
- Update Discord.Net library to version 2.3.0 (closes #121).
- Update copyright year to 2021 (closes #122).
