### PR TITLE
Announce reconnect change and item link bug fix

### DIFF
--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -231,7 +231,7 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <!-- Toggle broadcasts, chat, and world saves displayed in Discord -->");
         newConfigFile.WriteLine("  <silence broadcasts=\"false\" chat=\"false\" saves=\"false\" />\n");
         newConfigFile.WriteLine("  <!-- Notify Discord channel of relay availability after restoring the connection -->");
-        newConfigFile.WriteLine("  <announce reconnect=\"true\" />\n");
+        newConfigFile.WriteLine("  <announce reconnect=\"false\" />\n");
         newConfigFile.WriteLine("  <!-- Message sent to Discord text channel when the relay becomes available -->");
         newConfigFile.WriteLine("  <available text=\"**:white_check_mark: Relay available.**\" />\n");
         newConfigFile.WriteLine("  <!-- Message sent to Discord text channel when the relay is shutting down -->");

--- a/Terracord/Util.cs
+++ b/Terracord/Util.cs
@@ -259,6 +259,7 @@ namespace FragLand.TerracordPlugin
         modifiedMessage = Regex.Replace(modifiedMessage, itemSizePattern, m => $"**[{TShock.Utils.GetItemById(int.Parse(m.Groups[2].Value)).Name} ({m.Groups[1].Value})]**", RegexOptions.IgnoreCase);
       if(Regex.IsMatch(modifiedMessage, itemPrefixSizePattern))
         modifiedMessage = Regex.Replace(modifiedMessage, itemPrefixSizePattern, m => $"**[{TShock.Utils.GetPrefixById(int.Parse(m.Groups[1].Value))} {TShock.Utils.GetItemById(int.Parse(m.Groups[3].Value)).Name} ({m.Groups[2].Value})]**", RegexOptions.IgnoreCase);
+      modifiedMessage = Regex.Replace(modifiedMessage, @"\]\*{4}\[", "]** **["); // Discord bold formatting workaround
       return modifiedMessage;
     }
 

--- a/TerracordTest/TerracordTest.cs
+++ b/TerracordTest/TerracordTest.cs
@@ -75,7 +75,7 @@ namespace FragLand.TerracordPluginTests
       Assert.IsType<bool>(Config.SilenceChat);
       Assert.False(Config.SilenceSaves);
       Assert.IsType<bool>(Config.SilenceSaves);
-      Assert.True(Config.AnnounceReconnect);
+      Assert.False(Config.AnnounceReconnect);
       Assert.IsType<bool>(Config.AnnounceReconnect);
       Assert.Equal("**:white_check_mark: Relay available.**", Config.AvailableText);
       Assert.IsType<string>(Config.AvailableText);

--- a/terracord.xml
+++ b/terracord.xml
@@ -37,7 +37,7 @@
   <silence broadcasts="false" chat="false" saves="false" />
 
   <!-- Notify Discord channel of relay availability after restoring the connection -->
-  <announce reconnect="true" />
+  <announce reconnect="false" />
 
   <!-- Message sent to Discord text channel when the relay becomes available -->
   <available text="**:white_check_mark: Relay available.**" />


### PR DESCRIPTION
## Proposed Changes
- Fix Discord double bold formatting bug (closes #131).
- Set `announce reconnect` to `false` by default (closes #132).