### PR TITLE
Allow $world_name in status/topic, increment version, and update TShock release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ jobs:
         - nuget install xunit.runner.console -Version 2.4.1 -OutputDirectory testrunner
         - TMPDIR=tmp
         - mkdir $TMPDIR
-        - ZIPFILE=TShock.4.5.1.Terraria.1.4.2.1.zip
+        - ZIPFILE=TShock4.5.5_Terraria_1.4.2.3.zip
         #- ZIPDIR=TShock.4.5.1.Terraria.1.4.2.1
         - cd $TMPDIR
-        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.5.1/TShock.4.5.1.Terraria.1.4.2.1.zip
+        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.5.5/TShock4.5.5_Terraria_1.4.2.3.zip
         #- unzip -jq $ZIPFILE $ZIPDIR/OTAPI.dll $ZIPDIR/TerrariaServer.exe $ZIPDIR/ServerPlugins/TShockAPI.dll
         - unzip -jq $ZIPFILE OTAPI.dll TerrariaServer.exe ServerPlugins/TShockAPI.dll
         - mkdir -p ../lib
@@ -36,10 +36,10 @@ jobs:
         - dotnet restore
         - TMPDIR=tmp
         - mkdir $TMPDIR
-        - ZIPFILE=TShock.4.5.1.Terraria.1.4.2.1.zip
+        - ZIPFILE=TShock4.5.5_Terraria_1.4.2.3.zip
         #- ZIPDIR=TShock.4.5.1.Terraria.1.4.2.1
         - cd $TMPDIR
-        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.5.1/TShock.4.5.1.Terraria.1.4.2.1.zip
+        - curl -fsSLJo $ZIPFILE https://github.com/Pryaxis/TShock/releases/download/v4.5.5/TShock4.5.5_Terraria_1.4.2.3.zip
         #- unzip -jq $ZIPFILE $ZIPDIR/OTAPI.dll $ZIPDIR/TerrariaServer.exe $ZIPDIR/ServerPlugins/TShockAPI.dll
         - unzip -jq $ZIPFILE OTAPI.dll TerrariaServer.exe ServerPlugins/TShockAPI.dll
         - mkdir -p ../lib

--- a/Terracord/Config.cs
+++ b/Terracord/Config.cs
@@ -217,7 +217,7 @@ namespace FragLand.TerracordPlugin
         Util.Log($"Attempting to generate {TerracordPath}terracord.xml since the file did not exist...", Util.Severity.Info);
         StreamWriter newConfigFile = new StreamWriter($"{TerracordPath}terracord.xml", false);
         newConfigFile.WriteLine("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
-        newConfigFile.WriteLine("<!-- Terracord configuration version 1.2.3 -->");
+        newConfigFile.WriteLine("<!-- Terracord configuration version 1.3.1 -->");
         newConfigFile.WriteLine("<configuration>\n");
         newConfigFile.WriteLine("  <!-- Discord bot token -->");
         newConfigFile.WriteLine("  <bot token=\"ABC\" />\n");
@@ -234,9 +234,9 @@ namespace FragLand.TerracordPlugin
         newConfigFile.WriteLine("  <!-- List of space-separated Discord roles authorized to execute TShock commands remotely -->");
         newConfigFile.WriteLine("  <authorized roles=\"Administrators Moderators\" />\n");
         newConfigFile.WriteLine("  <!-- Discord bot game for \"playing\" status -->");
-        newConfigFile.WriteLine("  <game status=\"$server_name: $player_count/$player_slots\" />\n");
+        newConfigFile.WriteLine("  <game status=\"$server_name: $world_name: $player_count/$player_slots\" />\n");
         newConfigFile.WriteLine("  <!-- Topic update interval in seconds and topic to set when relay is offline -->");
-        newConfigFile.WriteLine("  <topic interval=\"300\" offline=\"Relay offline\" online=\"$server_name | $player_count/$player_slots players online | Server online for $uptime | Last update: $current_time\" />\n");
+        newConfigFile.WriteLine("  <topic interval=\"300\" offline=\"Relay offline\" online=\"$server_name: $world_name | $player_count/$player_slots players online | Server online for $uptime | Last update: $current_time\" />\n");
         newConfigFile.WriteLine("  <!-- Terraria broadcast color in RGB -->");
         newConfigFile.WriteLine("  <color red=\"255\" green=\"215\" blue=\"0\" />\n");
         newConfigFile.WriteLine("  <!-- Toggle broadcasts, chat, and world saves displayed in Discord -->");

--- a/Terracord/Discord.cs
+++ b/Terracord/Discord.cs
@@ -86,6 +86,7 @@ namespace FragLand.TerracordPlugin
       {
         // Set game/playing status
         string status = Config.BotGame.Replace("$server_name", TShock.Config.Settings.ServerName);
+        status = status.Replace("$world_name", Terraria.Main.worldName);
         status = status.Replace("$player_count", TShock.Utils.GetActivePlayerCount().ToString());
         status = status.Replace("$player_slots", TShock.Config.Settings.MaxSlots.ToString());
         await Client.SetGameAsync(status).ConfigureAwait(true);
@@ -287,6 +288,7 @@ namespace FragLand.TerracordPlugin
       while(true)
       {
         string topic = Config.OnlineTopic.Replace("$server_name", TShock.Config.Settings.ServerName);
+        topic = topic.Replace("$world_name", Terraria.Main.worldName);
         topic = topic.Replace("$player_count", TShock.Utils.GetActivePlayerCount().ToString());
         topic = topic.Replace("$player_slots", TShock.Config.Settings.MaxSlots.ToString());
         topic = topic.Replace("$uptime", Command.Uptime());

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -254,6 +254,7 @@ namespace FragLand.TerracordPlugin
           {
             message = message.Replace("$player_name", playerName);
             string status = Config.BotGame.Replace("$server_name", TShock.Config.Settings.ServerName);
+            status = status.Replace("$world_name", Terraria.Main.worldName);
             status = status.Replace("$player_count", playerCount.ToString());
             status = status.Replace("$player_slots", TShock.Config.Settings.MaxSlots.ToString());
             Discord.UpdateBotGame(discord.Client, status).ConfigureAwait(true);

--- a/Terracord/Terracord.cs
+++ b/Terracord/Terracord.cs
@@ -39,7 +39,7 @@ namespace FragLand.TerracordPlugin
     /// <summary>
     /// Plugin version
     /// </summary>
-    public override Version Version => new Version(1, 3, 0);
+    public override Version Version => new Version(1, 3, 1);
 
     /// <summary>
     /// Plugin author(s)
@@ -52,7 +52,7 @@ namespace FragLand.TerracordPlugin
     public override string Description => "A Discord <-> Terraria bridge plugin for TShock";
 
     // Plugin version
-    public const string PluginVersion = "1.3.0";
+    public const string PluginVersion = "1.3.1";
     // Discord bot client
     private readonly Discord discord;
     // Plugin start time

--- a/Terracord/Terracord.csproj
+++ b/Terracord/Terracord.csproj
@@ -5,11 +5,11 @@
     <!-- <TargetFramework>netstandard2.0</TargetFramework> -->
     <!-- <TargetFramework>netcoreapp3.1</TargetFramework> -->
     <!-- Discord.Net 2.1.1 requires >=net46 -->
-    <!-- Discord.Net 2.3.0 requires >=net461 -->
+    <!-- Discord.Net 2.3.0 and 2.4.0 requires >=net461 -->
     <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <Platforms>x86</Platforms>
     <Company>Frag Land</Company>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <PackageProjectUrl>http://www.frag.land/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/FragLand/terracord</RepositoryUrl>
@@ -27,8 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Core" Version="2.3.1" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.3.1" />
+    <PackageReference Include="Discord.Net.Core" Version="2.4.0" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Terracord/Terracord.nuspec
+++ b/Terracord/Terracord.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Terracord</id>
-    <version>1.2.3</version>
+    <version>1.3.1</version>
     <authors>Lloyd Dilley</authors>
     <license type="expression">GPL-3.0-or-later</license>
     <projectUrl>https://github.com/FragLand/terracord</projectUrl>

--- a/TerracordTest/TerracordTest.cs
+++ b/TerracordTest/TerracordTest.cs
@@ -57,13 +57,13 @@ namespace FragLand.TerracordPluginTests
       Assert.IsType<bool>(Config.RemoteCommands);
       Assert.Equal("Administrators Moderators", Config.AuthorizedRoles);
       Assert.IsType<string>(Config.AuthorizedRoles);
-      Assert.Equal("$server_name: $player_count/$player_slots", Config.BotGame);
+      Assert.Equal("$server_name: $world_name: $player_count/$player_slots", Config.BotGame);
       Assert.IsType<string>(Config.BotGame);
       Assert.Equal("300", Config.TopicInterval.ToString());
       Assert.IsType<uint>(Config.TopicInterval);
       Assert.Equal("Relay offline", Config.OfflineTopic);
       Assert.IsType<string>(Config.OfflineTopic);
-      Assert.Equal("$server_name | $player_count/$player_slots players online | Server online for $uptime | Last update: $current_time", Config.OnlineTopic);
+      Assert.Equal("$server_name: $world_name | $player_count/$player_slots players online | Server online for $uptime | Last update: $current_time", Config.OnlineTopic);
       Assert.IsType<string>(Config.OnlineTopic);
       Assert.Equal("255", Config.BroadcastColor[0].ToString());
       Assert.IsType<byte>(Config.BroadcastColor[0]);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
-version: 1.2.3.{build}
+version: 1.3.1.{build}
 image: Visual Studio 2019
 platform: x86
 configuration: Debug
 before_build:
   - nuget restore
   - SET TEMPDIR=temp
-  - SET ZIPFILE=TShock.4.5.1.Terraria.1.4.2.1.zip
+  - SET ZIPFILE=TShock4.5.5_Terraria_1.4.2.3.zip
   - md %TEMPDIR%
   - cd %TEMPDIR%
-  - curl -fsSLJo %ZIPFILE% https://github.com/Pryaxis/TShock/releases/download/v4.5.1/TShock.4.5.1.Terraria.1.4.2.1.zip
+  - curl -fsSLJo %ZIPFILE% https://github.com/Pryaxis/TShock/releases/download/v4.5.5/TShock4.5.5_Terraria_1.4.2.3.zip
   - 7z e %ZIPFILE% -o..\lib\ OTAPI.dll TerrariaServer.exe TShockAPI.dll -r
 build:
   # Ignore TerracordTest

--- a/terracord.xml
+++ b/terracord.xml
@@ -25,10 +25,10 @@
   <authorized roles="Administrators Moderators" />
 
   <!-- Discord bot game for "playing" status -->
-  <game status="$server_name: $player_count/$player_slots" />
+  <game status="$server_name: $world_name: $player_count/$player_slots" />
 
   <!-- Topic update interval in seconds and topics to set when relay is offline and online -->
-  <topic interval="300" offline="Relay offline" online="$server_name | $player_count/$player_slots players online | Server online for $uptime | Last update: $current_time" />
+  <topic interval="300" offline="Relay offline" online="$server_name: $world_name | $player_count/$player_slots players online | Server online for $uptime | Last update: $current_time" />
 
   <!-- Terraria broadcast color in RGB -->
   <color red="255" green="215" blue="0" />


### PR DESCRIPTION
## Proposed Changes
- Allow `$world_name` in bot status and channel topic (closes #152).
- Increment version to 1.3.1.
- Update TShock release for CI builds
